### PR TITLE
将 P2 路径的动画时间改为 `-0:0:1` 提前 1 秒

### DIFF
--- a/WpfDesignAndAnimationLab/Demos/GlowEffects/NeonLoveDemo.xaml
+++ b/WpfDesignAndAnimationLab/Demos/GlowEffects/NeonLoveDemo.xaml
@@ -26,7 +26,7 @@
                                              Storyboard.TargetProperty="StrokeDashOffset"
                                              To="89.8"
                                              Duration="0:0:2" />
-                            <ParallelTimeline BeginTime="0:0:1">
+                            <ParallelTimeline BeginTime="-0:0:1">
                                 <DoubleAnimation RepeatBehavior="Forever"
                                                  Storyboard.TargetName="P2"
                                                  Storyboard.TargetProperty="StrokeDashOffset"


### PR DESCRIPTION
将 P2 路径的动画时间改为 `-0:0:1` 提前 1 秒

Before:
![](https://user-images.githubusercontent.com/40764272/149464814-07ba98d7-cfa8-46b5-a00d-8debd8f18103.gif)

After:
![](https://user-images.githubusercontent.com/40764272/149464842-18451257-a46a-4e73-ad38-9e260544e3fb.gif)
